### PR TITLE
Add inclusivity into performance framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
       <ul>
         <li>Each quarter provides some mentoring or guidance to colleagues (e.g. mentoring, constructive PR reviews or discussing approaches online or offline).</li>
         <li>Always willing to help others.</li>
+        <li>Demonstrates inclusive behaviours as part of their everyday work.</li>
       </ul>
     </td>
     <td>
@@ -112,6 +113,7 @@
         <li>Regularly provides mentoring and guidance to colleagues and has become known for this. </li>
         <li>Undertakes departmental activities which uphold our departmental or engineering culture.</li>
         <li>Ensures the opinions of others in their team are heard and that decisions are made by consensus.</li>
+        <li>Participates in some activity which aims to improve the inclusivity of our department.</li>
       </ul>
     </td>
   </tr>
@@ -200,7 +202,7 @@
     <td>
       <ul>
         <li>Actively seeks to share knowledge with their colleagues, choosing communication method/styles that are appropriate to them and the situation.</li>
-        <li>Makes a positive contribution to the atmosphere and culture of the department.</li>
+        <li>Makes a positive contribution to the inclusivity, atmosphere and culture of the department.</li>
         <li>Regularly advises or mentors others in a way that accelerates their personal development.</li>
       </ul>
     </td>
@@ -208,7 +210,7 @@
       <ul>
         <li>Seeks to share knowledge beyond their team where useful/relevant (e.g delegates learning opportunities).</li>
         <li>Consistently communicates the intention and outcomes from their work, leaving their work in a state where others can easily pick it up (e.g produces well worded requirements, PRs, documentation, etc). Encourages this behaviour in others.</li>
-        <li>Engages with departmental activities which improve our company or engineering culture.</li>
+        <li>Engages with departmental activities which improve our company or engineering culture and inclusivity.</li>
         <li>Proactively encourages others to share their opinions and insight. Manages their own input to discussions to ensure they do not overly influence decisions.</li>
         <li>Coaches and mentors their colleagues to perform better, be happy, motivated and fulfilled in the work they undertake.</li>
       </ul>


### PR DESCRIPTION
Becoming a more inclusive place to work is something that is important to us but isn't explicitly called out in the performance framework.  This may create the feeling that working on this problem is optional and/or something that is not "work".  This PR makes some small changes to the framework to make it clear that creating an inclusive environment is everyone's responsibility.