### PR TITLE
Add inclusion to EM performance framework

### DIFF
--- a/management/engineering-manager.md
+++ b/management/engineering-manager.md
@@ -47,6 +47,20 @@
         <ul>
           <li>Read submissions for non line managed individuals</li>
         </ul>
+        <li>Inclusion</li>
+        <ul>
+          <li>
+            Regularly discuss inclusivity with their line reports, helping those
+            who exhibit non-inclusive behaviour to improve in this area, and
+            helping all of their reports to increase the level of inclusion in
+            the department
+          </li>
+          <li>
+            Able to discuss specific instances of non-inclusive behaviour with
+            individuals after the fact, discussing the impact and changing
+            future behaviour
+          </li>
+        </ul>
       </ul>
     </td>
     <td>
@@ -145,6 +159,17 @@
             clearly to stakeholders.
           </li>
         </ul>
+        <li>Inclusion</li>
+        <ul>
+          <li>
+            Ensure reliable long-term delivery by sharing knowledge across the
+            whole team
+          </li>
+          <li>
+            Ensure all team members are provided with learning and growth
+            opportunities, as an investment in future delivery performance
+          </li>
+        </ul>
       </ul>
     </td>
     <td>
@@ -198,6 +223,18 @@
             Ensures that all members of their team have a clear grasp of the KR
             for their products and that they are focused on improving them
           </li>
+          <li>
+            Consider inclusivity when making decisions about their team’s
+            direction, and the effect of their behaviour on how inclusive their
+            team is.
+          </li>
+          <li>Empower all members of your team to make decisions</li>
+          <li>Ensure everyone’s voice is heard</li>
+          <li>
+            Judge when to call out non-inclusive behaviour in the moment, and
+            when to follow up on a 1-2-1 basis
+          </li>
+          <li>Ensure decisions are made in a transparent way</li>
         </ul>
         <li>Stakeholders</li>
         <ul>

--- a/management/engineering-manager.md
+++ b/management/engineering-manager.md
@@ -5,66 +5,87 @@
 
 
 <table>
-  <tr> <th width="50%"> Level 2 </th><th with="50%"> Level 3</th></tr>
+  <tr>
+    <th width="50%">Level 2</th>
+    <th with="50%">Level 3</th>
+  </tr>
   <tr>
     <td>
       <ul>
-        <li>Demonstrate people development skills of individual contributors </li>
+        <li>
+          Demonstrate people development skills of individual contributors
+        </li>
         <ul>
-         <li> motivating </li>
-         <li> coaching </li>
-        <li> mentoring </li>
-        <li> empowering </li>
-        <li> helping individual to increase their performance </li>
+          <li>motivating</li>
+          <li>coaching</li>
+          <li>mentoring</li>
+          <li>empowering</li>
+          <li>helping individual to increase their performance</li>
         </ul>
-  <li> Manage performance of significant number of individuals (6) </li>
-  <ul>
-         <li>1:1 </li>
-         <li> Onboarding new members, helping them to make the most of their onboarding.</li>
-        <li> Career development & progression</li>
-        <li> Handling leaving members</li>
- </ul>
-<li>Engineering management team</li>
-  <ul>
-  <li>Participate actively in led by other departemental initiatives</li>
-  <li>Participate actively in management meetings</li>
-</ul>
-
-<li> Performance calibrations</li>
-  <ul><li> Read and share feedback for some non line managed individuals </li></ul>
-
-<li>Promotions and In-band payrise</li>
-<ul><li> Read submissions for non line managed individuals</li></ul>
+        <li>Manage performance of significant number of individuals (6)</li>
+        <ul>
+          <li>1:1</li>
+          <li>
+            Onboarding new members, helping them to make the most of their
+            onboarding.
+          </li>
+          <li>Career development & progression</li>
+          <li>Handling leaving members</li>
+        </ul>
+        <li>Engineering management team</li>
+        <ul>
+          <li>
+            Participate actively in led by other departemental initiatives
+          </li>
+          <li>Participate actively in management meetings</li>
+        </ul>
+        <li>Performance calibrations</li>
+        <ul>
+          <li>Read and share feedback for some non line managed individuals</li>
+        </ul>
+        <li>Promotions and In-band payrise</li>
+        <ul>
+          <li>Read submissions for non line managed individuals</li>
+        </ul>
       </ul>
     </td>
     <td>
       <ul>
-        <li>Demonstrate people development skills of individual contributors</li>
+        <li>
+          Demonstrate people development skills of individual contributors
+        </li>
         <ul>
-          <li> Is being recognised for helping individuals to improve </li>
-          <li> Provide extensive feedback to indiviudal on how to improve </li>
+          <li>Is being recognised for helping individuals to improve</li>
+          <li>Provide extensive feedback to indiviudal on how to improve</li>
         </ul>
         <li>Performance calibrations</li>
         <ul>
-          <li> Read and share feedback for a significant number of non line managed individuals </li>
+          <li>
+            Read and share feedback for a significant number of non line managed
+            individuals
+          </li>
         </ul>
-        <li> Promotions and In-band payrise </li>
-         <ul>
-          <li> Read and share feedback for some non line managed individuals </li>
+        <li>Promotions and In-band payrise</li>
+        <ul>
+          <li>Read and share feedback for some non line managed individuals</li>
         </ul>
-        <li> Quarterly rotation </li>
-         <ul>
-          <li> Actively look for opportunities in the coming quarters for managed individuals </li>
-          <li> Help resolve rotation gap suggesting individuals that would best fit </li>
+        <li>Quarterly rotation</li>
+        <ul>
+          <li>
+            Actively look for opportunities in the coming quarters for managed
+            individuals
+          </li>
+          <li>
+            Help resolve rotation gap suggesting individuals that would best fit
+          </li>
         </ul>
-         <li> Hiring & Handling resignation </li>
-         <ul>
-          <li> Suggest improvements to hiring process and activities </li>
-          <li> Convince people to remain when handling their resignation </li>
+        <li>Hiring & Handling resignation</li>
+        <ul>
+          <li>Suggest improvements to hiring process and activities</li>
+          <li>Convince people to remain when handling their resignation</li>
         </ul>
       </ul>
     </td>
-
   </tr>
 </table>
 
@@ -73,7 +94,10 @@
 
 
 <table>
-  <tr> <th width="50%"> Level 2 </th><th with="50%"> Level 3</th></tr>
+  <tr>
+    <th width="50%">Level 2</th>
+    <th with="50%">Level 3</th>
+  </tr>
   <tr>
     <td>
       <ul>
@@ -89,26 +113,37 @@
           <li>Is conscious about team delivery pace</li>
           <li>Understand impact of management on it.</li>
           <li>Identify bottlenecks in delivery pace</li>
-          <li>Collaborate on continuously improving pace of their team </li>
+          <li>Collaborate on continuously improving pace of their team</li>
         </ul>
         <li>Health</li>
         <ul>
-          <li>Participate in definining key metrics for systems owned by team</li>
+          <li>
+            Participate in definining key metrics for systems owned by team
+          </li>
           <li>Ensure team monitors key metrics for systems owned by team</li>
           <li>Evaluate and decide time to spend on health each quarter</li>
           <li>Demonstrate improvements on specific key metrics</li>
         </ul>
         <li>Technical contribution</li>
         <ul>
-          <li>Continue to write code at least once a week and release features, but avoid being on the critical path.</li>
-          <li>Continue to review significant PR and talking through problems with team members</li>
+          <li>
+            Continue to write code at least once a week and release features,
+            but avoid being on the critical path.
+          </li>
+          <li>
+            Continue to review significant PR and talking through problems with
+            team members
+          </li>
           <li>Continue to help diagnosing issue or fix some of them</li>
         </ul>
         <li>Context awareness</li>
         <ul>
           <li>Understands the constraints placed on the business.</li>
           <li>Demonstrate flexibility to adapt to those constraints.</li>
-          <li>Understands the capabilities of their team and communicates that clearly to stakeholders.</li>
+          <li>
+            Understands the capabilities of their team and communicates that
+            clearly to stakeholders.
+          </li>
         </ul>
       </ul>
     </td>
@@ -118,44 +153,63 @@
         <ul>
           <li>Resolve bottlenecks in delivery pace</li>
           <li>Share with senior managers opportunity to improve</li>
-          <li>Ensure small changes with high impact are released quickly not just added to the backlog </li>
+          <li>
+            Ensure small changes with high impact are released quickly not just
+            added to the backlog
+          </li>
         </ul>
         <li>Health</li>
         <ul>
-          <li>Ensure the right balance between Health and OKR between quarters,engaging product and scrum master in the process</li>
+          <li>
+            Ensure the right balance between Health and OKR between
+            quarters,engaging product and scrum master in the process
+          </li>
         </ul>
         <li>Context awareness</li>
         <ul>
-          <li>Suggest reasonable changes to the constraints that help solve stakeholder issues</li>
+          <li>
+            Suggest reasonable changes to the constraints that help solve
+            stakeholder issues
+          </li>
         </ul>
       </ul>
     </td>
   </tr>
 </table>
 
+
 #### ▶️ Leadership
 
 
 <table>
-  <tr> <th width="50%"> Level 2 </th><th with="50%"> Level 3</th></tr>
+  <tr>
+    <th width="50%">Level 2</th>
+    <th with="50%">Level 3</th>
+  </tr>
   <tr>
     <td>
       <ul>
         <li>Team</li>
         <ul>
-        <li>Communicate progress and achievements to the department</li>
-        <li>Recognise outstanding works from individuals within team</li>
-        <li>Ensure there is, but don't orgnanise, demo of team work</li>
-        <li>Ensures that all members of their team have a clear grasp of the KR for their products and that they are focused on improving them</li>
+          <li>Communicate progress and achievements to the department</li>
+          <li>Recognise outstanding works from individuals within team</li>
+          <li>Ensure there is, but don't orgnanise, demo of team work</li>
+          <li>
+            Ensures that all members of their team have a clear grasp of the KR
+            for their products and that they are focused on improving them
+          </li>
         </ul>
         <li>Stakeholders</li>
         <ul>
-        <li>Communicate technical challenges and opportunities in the domain area of their team in a clear way to stakeholders</li>
+          <li>
+            Communicate technical challenges and opportunities in the domain
+            area of their team in a clear way to stakeholders
+          </li>
         </ul>
         <li>Strategy</li>
         <ul>
-        <li>Share technical opportunities with their manager </li>
-        <li>Participate in defining OKR team with product manager</li>
+          <li>Share technical opportunities with their manager</li>
+          <li>Participate in defining OKR team with product manager</li>
         </ul>
       </ul>
     </td>
@@ -163,46 +217,60 @@
       <ul>
         <li>Ownership</li>
         <ul>
-        <li>Clearly communicate and share ownership of existing systems </li>
-        <li>Help decide where ownership of new systems seat</li>
+          <li>Clearly communicate and share ownership of existing systems</li>
+          <li>Help decide where ownership of new systems seat</li>
         </ul>
         <li>Evangelise simplicity</li>
         <ul>
-        <li> Engage with product in removing rarely used features </li>
-        <li> Encourage clear and readable code, organised in way that divides implementation in independant units of work</li>
-        <li> Promote a change that reduce size of code base </li>
+          <li>Engage with product in removing rarely used features</li>
+          <li>
+            Encourage clear and readable code, organised in way that divides
+            implementation in independant units of work
+          </li>
+          <li>Promote a change that reduce size of code base</li>
         </ul>
       </ul>
     </td>
-
   </tr>
 </table>
 
+
 #### 💷 Costs Managements
 
+
 <table>
-  <tr> <th width="50%"> Level 2 </th><th with="50%"> Level 3</th></tr>
+  <tr>
+    <th width="50%">Level 2</th>
+    <th with="50%">Level 3</th>
+  </tr>
   <tr>
     <td>
       <ul>
         <li>Health</li>
         <ul>
-        <li>Monitor system and delivery pipeline health</li>
-        <li>Participate in defining health tasks</li>
-        <li>Share with stakeholders importance of health for sustainability</li>
+          <li>Monitor system and delivery pipeline health</li>
+          <li>Participate in defining health tasks</li>
+          <li>
+            Share with stakeholders importance of health for sustainability
+          </li>
         </ul>
         <li>Operating costs</li>
         <ul>
-        <li>Understand details of costs structure</li>
-        <li>Participate in costs reduction initiatives</li>
-        <li>Ensure costs remain within allocated budget</li>
+          <li>Understand details of costs structure</li>
+          <li>Participate in costs reduction initiatives</li>
+          <li>Ensure costs remain within allocated budget</li>
         </ul>
       </ul>
     </td>
     <td>
       <ul>
         <li>Operating costs</li>
-        <ul><li>Evaluate costs of new projects providing recommendations for cost-efficiency and trade-offs</li></ul>
+        <ul>
+          <li>
+            Evaluate costs of new projects providing recommendations for
+            cost-efficiency and trade-offs
+          </li>
+        </ul>
       </ul>
     </td>
   </tr>


### PR DESCRIPTION
Adds some specific sections on inclusion to the EM performance framework.  Also includes purely HTML reformatting commit, so you might find it easier to just review https://github.com/guardian/engineering-performance-framework/commit/5611e5c42cbc2b387d4a64157a09148ff95dbfd9