### PR TITLE
Add engineering salary bands

### DIFF
--- a/salary-bands.md
+++ b/salary-bands.md
@@ -1,0 +1,36 @@
+Our salary bands are public and can be seen below.
+
+* **Individual Contributor**
+
+    *  Associate Developer: `£36.2k - £49.6k` 
+    *  Developer: `£49.6k - £65.2k` 
+    *  Senior Developer: `£65.2k - £77.6k`
+    *  Staff Developer: `£77.6k - £88k`
+    *  Principal Developer: `£100k`  
+
+
+* **Individual Contributor** — Apps Engineering: iOS, Android, and cross-platform apps software developers
+
+    *  Associate: `£40k - £60k` 
+    *  Developer: `£60k - £80k` 
+    *  Senior: `£80k - £90k`
+    *  Staff: `£90k - £100k`  
+
+
+* **Individual Contributor** — Data Engineering
+
+    *  Associate: `£50k - £70k` 
+    *  Engineer: `£70k - £80k` 
+    *  Senior: `£80k - £90k`
+    *  Staff: `£90k - £100k`
+
+
+* **Engineering Management**
+
+    *  Associate: `£65k - £75k` 
+    *  Manager: `£75k - £85k` 
+    *  Senior: `£85k - £96k`
+    *  Head of: `£120k`
+
+
+


### PR DESCRIPTION
We are sharing already our starting salary in each offer and have pay bands.
Having them written on a publicly available document  for existing employee and external people, like we have done for our performance framework, has multiple benefits:

- Ensure that every candidate interested to apply has a fair access to that knowledge 
-  
- Simplify the onboarding of new starters 

Subjects that still need to be documented in this repository:
- [ ] How we are making offers
- [ ] Basic progression process

