### PR TITLE
Update to mid-level developer, delivery criteria.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ See the following [Indeed.com article for the difference between an "Individual 
     <td>
       <ul>
         <li>Identifies problems to solve and engages the team in scoping and prioritising their delivery.</li>
-        <li>Delivers outcomes ahead of schedule.</li>
+        <li>Demonstrates an understanding of external schedule constraints and calls out potential issues during estimation</li>
         <li>Evaluates multiple options to solve technical problems and is trusted by the team to implement their recommended solution.</li>
         <li>Regularly reviews team PRs providing helpful comments (e.g. constructive criticism / alternative approaches). Occasionally reviews PRs in projects where they have less context (e.g. outside their immediate team or dormant projects) with the same consideration.</li>
         <li>Helps to unblock their peers or shares responsibility for their tasks, in order to meet the team delivery goals.</li>


### PR DESCRIPTION
The previous criteria, it could be argued incentivises overly cautious estimation, and penalises accurate estimation and planning.

The other option I had was simply `Estimates well, and delivers outcomes accordingly`

| Old      |  Updated |
| ----------- | ----------- |
| Delivers outcomes ahead of schedule.      | Demonstrates an understanding of external schedule constraints and calls out potential issues during estimation       |