### PR TITLE
Clarification of 'requires occasional support'

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ See the following [Indeed.com article for the difference between an "Individual 
         <li>Takes responsibility of their code from local testing to supporting it in production.</li>
         <li>Only occasionally requires supportfrom peers depending on the task, technology and prior experience.</li>
         <li>Regularly reviews team PRs.</li>
-        <li>Attempts to unblock themselves first before seeking help.</li>
+        <li>Recognises when they’re near their limit and reaches out for help from others.</li>
       </ul>
     </td>
     <td>

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See the following [Indeed.com article for the difference between an "Individual 
         <li>Breaks down large problems into deliverable tasks.</li>
         <li>Delivers incremental changes frequently, reliably and with consistently good quality (e.g readable code which adheres to team standards).</li>
         <li>Takes responsibility of their code from local testing to supporting it in production.</li>
-        <li>Requires occasional support from peers depending on the task, technology and prior experience.</li>
+        <li>Only occasionally requires supportfrom peers depending on the task, technology and prior experience.</li>
         <li>Regularly reviews team PRs.</li>
         <li>Attempts to unblock themselves first before seeking help.</li>
       </ul>

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See the following [Indeed.com article for the difference between an "Individual 
         <li>Breaks down large problems into deliverable tasks.</li>
         <li>Delivers incremental changes frequently, reliably and with consistently good quality (e.g readable code which adheres to team standards).</li>
         <li>Takes responsibility of their code from local testing to supporting it in production.</li>
-        <li>Only occasionally requires supportfrom peers depending on the task, technology and prior experience.</li>
+        <li>Only occasionally requires support from peers depending on the task, technology and prior experience.</li>
         <li>Regularly reviews team PRs.</li>
         <li>Recognises when they’re near their limit and reaches out for help from others.</li>
       </ul>


### PR DESCRIPTION
To make it clearer that the goal is that the individual needs less support. Someone who needs no support is meeting the expectation.

Current | Proposed
-- | --
Requires occasional support from peers depending on the task, technology and prior experience | Only occasionally requires support from peers depending on the task, technology and prior experience

In conjunction with this change the following change replaces what would otherwise be a repetition of the above, with making sure we're not inhibiting people from asking for help when they need it, which is also a skill.

Current | Proposed
-- | --
Attempts to unblock themselves first before seeking help. | Recognises when they’re near their limit and reaches out for help from others
