### PR TITLE
Add data-related Engineering criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Takes on bigger pieces of work with support.</li>
         <li>Takes on PR feedback and improves their work.</li>
         <li>Seeks advice from more senior engineers when they are blocked.</li>
-        <li>Shows awareness of data privacy or security concerns where relevant.</li>
+        <li>Shows awareness of data privacy or security concerns where relevant.†</li>
       </ul>
     </td>
     <td>
@@ -109,7 +109,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Contributes ideas for solutions and process improvements in team discussions, and is able to build on the ideas of others.</li>
         <li>Actively exploring new approaches in their own work.</li>
-        <li>Uses relevant data or metrics as an input to solutions.</li>
+        <li>Uses relevant data or metrics as an input to solutions.†</li>
       </ul>
     </td>
   </tr>
@@ -186,7 +186,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Identifies problems to solve and engages the team in scoping and prioritising their delivery.</li>
         <li>Demonstrates an understanding of external schedule constraints and calls out potential issues during estimation</li>
-        <li>Evaluates multiple options to solve technical problems using data where relevant, and is trusted by the team to implement their recommended solution.</li>
+        <li>Evaluates multiple options to solve technical problems using data where relevant†, and is trusted by the team to implement their recommended solution.</li>
         <li>Regularly reviews team PRs providing helpful comments (e.g. constructive criticism / alternative approaches). Occasionally reviews PRs in projects where they have less context (e.g. outside their immediate team or dormant projects) with the same consideration.</li>
         <li>Helps to unblock their peers or shares responsibility for their tasks, in order to meet the team delivery goals.</li>
       </ul>
@@ -209,7 +209,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Regularly introduces new technical approaches when appropriate, which are adopted by the team, and make the team more effective. </li>
         <li>Keeps up to date with evolving best practice in their field.</li>
-        <li>Works with Product and Engineering Managers to ensure most useful product data is gathered and available for decision making.</li>
+        <li>Works with Product and Engineering Managers to ensure most useful product data is gathered and available for decision making.†</li>
       </ul>
     </td>
   </tr>
@@ -228,7 +228,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Provides input into architectural design choices. </li>
         <li>Regularly demos their work to the stream. </li>
         <li>Encourages their colleagues to do their best work.</li>
-        <li>Uses relevant data and metrics to inform new ideas and make persuasive arguments</li>
+        <li>Uses relevant data and metrics to inform new ideas and make persuasive arguments.†</li>
       </ul>
     </td>
     <td>
@@ -279,7 +279,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Delivers reliably and with consistently good quality code (e.g. well tested and readable) which defines team standards.</li>
         <li>Takes responsibility of their code from local testing to supporting it in production.</li>
-        <li>Regularly reviews team PRs providing helpful comments, constructive criticism or suggested alternative approaches, using relevant data and metrics where approriate.</li>
+        <li>Regularly reviews team PRs providing helpful comments, constructive criticism or suggested alternative approaches, using relevant data and metrics† where approriate.</li>
         <li>Demonstrates understanding that delivery goes beyond their individual contribution. (E.g. encourages others to improve their own delivery; manages dependencies on other projects and teams; balances short-term delivery with longer term objectives of own and other teams).</li>
         <li>Committed to meeting their team’s objective and key results. (E.g. adapts delivery approach to meet the needs of the team, unblocks obstacles and supports the team in delivering its goals).</li>
         <li>Regularly takes on more difficult tasks which require input from various teams or disciplines.</li>
@@ -316,7 +316,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Leads by example to promote and encourage a culture of continuous improvement within their team.</li>
         <li>Performs detailed R&D on new technologies and architecture patterns, and frames and shares the results accordingly.</li>
         <li>Ensures that all members of the team are brought on board with new solutions, processes and technologies.</li>
-        <li>Works with Product, UX and other relevant disciplines to identify potential new opportunities for the business based on data.</li>
+        <li>Works with Product, UX and other relevant disciplines to identify potential new opportunities for the business based on data.†</li>
       </ul>
     </td>
   </tr>
@@ -380,7 +380,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
   <tr>
     <td>
       <ul>
-        <li>Plays a strategic role in the stream’s technical decision making through data-driven decision-making whenever possible.</li>
+        <li>Plays a strategic role in the stream’s technical decision making through data-driven decision-making whenever possible†.</li>
         <li>Produces high quality code which defines stream standards, and inspires other engineers’ delivery.</li>
         <li>Provides feedback on important PRs and team’s solution design sessions.</li>
         <li>Fosters a culture of continuous improvement and high delivery momentum across the stream.</li>
@@ -515,8 +515,12 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Leads collaborative discussions around evolving best practices, defining our engineering standards.</li>
         <li>Seeks out systemic problems and opportunities, and presents proposals to the Head of Engineering on how to, respectively, remediate them and benefit from them.</li>
         <li>Advises on new technology trials based on your previous experience, and mentor more junior developers in their technical discovery and technology intelligence.</li>
-        <li>Is able to effectively work with Product and other disciplines to communicate data insights using narratives, and where appropriate visualizations, to put data insights into context and inspire action from, and give direction to, colleages and stakeholders across the business.</li>
+        <li>Is able to effectively work with Product and other disciplines to communicate data insights using narratives, and where appropriate visualizations, to put data insights into context and inspire action from, and give direction to, colleages and stakeholders across the business.†</li>
       </ul>
     </td>
   </tr>
 </table>
+
+† - Criteria marked with the 'obelisk' icon are new changes (2023-June) that are optional until after the current review round.
+The Engineering Management team are reviewing the progression and promotion frameworks generally, including adding data-related responsibilities. However we believe it's unfair to make changes to the criteria shortly before a review round.
+For now - feel free to provide evidence towards them, or delete them.

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Champions Guardian P&E solutions, culture and values externally. For example by hosting external meet-ups, presenting at conferences, or writing blog posts. </li>
         <li>Enables software to be produced that can be used by, or benefits external communities.</li>
         <li>Ensures we don’t encounter unmitigatable or unforeseen technical problems.</li>
-        <li>Is abile to make sense of data and communicate it as easy-to-understand stories that help inspire insights to become actions.</li>
+        <li>Is able to make sense of data and present it in easy-to-understand and inspiring formats</li>
       </ul>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -520,6 +520,6 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
   </tr>
 </table>
 
-† - Criteria marked with the 'obelisk' icon are new changes (2023-June) that are optional until after the current review round.
+† - Criteria marked with the 'obelisk' icon are new changes (2024-May) that are optional until after the current review round.
 The Engineering Management team are reviewing the progression and promotion frameworks generally, including adding data-related responsibilities. However we believe it's fair that changes to criteria are made and established well before a review round.
 For now - feel free to provide evidence towards them, or delete them.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Contributes ideas for solutions and process improvements in team discussions, and is able to build on the ideas of others.</li>
         <li>Actively exploring new approaches in their own work.</li>
-        <li>Uses relevant data or metrics as an input to solutions.†</li>
+        <li>Uses relevant data or metrics as an input to solutions when relevant.†</li>
       </ul>
     </td>
   </tr>
@@ -186,7 +186,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Identifies problems to solve and engages the team in scoping and prioritising their delivery.</li>
         <li>Demonstrates an understanding of external schedule constraints and calls out potential issues during estimation</li>
-        <li>Evaluates multiple options to solve technical problems using data where relevant†, and is trusted by the team to implement their recommended solution.</li>
+        <li>Evaluates multiple options to solve technical problems (using data where relevant†), and is trusted by the team to implement their recommended solution.</li>
         <li>Regularly reviews team PRs providing helpful comments (e.g. constructive criticism / alternative approaches). Occasionally reviews PRs in projects where they have less context (e.g. outside their immediate team or dormant projects) with the same consideration.</li>
         <li>Helps to unblock their peers or shares responsibility for their tasks, in order to meet the team delivery goals.</li>
       </ul>
@@ -203,7 +203,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Critically evaluates innovative concepts and ideas presented by others.</li>
         <li>Suggests and helps to implement process improvements and engineering best practice.</li>
-        <li>Works with Product and others to ensure the most useful product data is gathered and available for decision making.†</li>
+        <li>Works with one or more of Product Managers / Engineering Managers / Data Analysts to ensure the most useful product data is gathered and available for analysis & decision making.†</li>
       </ul>
     </td>
     <td>
@@ -279,7 +279,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Delivers reliably and with consistently good quality code (e.g. well tested and readable) which defines team standards.</li>
         <li>Takes responsibility of their code from local testing to supporting it in production.</li>
-        <li>Regularly reviews team PRs providing helpful comments, constructive criticism or suggested alternative approaches, using relevant data and metrics† where approriate.</li>
+        <li>Regularly reviews team PRs providing helpful comments, constructive criticism or suggested alternative approaches (using relevant data and metrics where relevant†).</li>
         <li>Demonstrates understanding that delivery goes beyond their individual contribution. (E.g. encourages others to improve their own delivery; manages dependencies on other projects and teams; balances short-term delivery with longer term objectives of own and other teams).</li>
         <li>Committed to meeting their team’s objective and key results. (E.g. adapts delivery approach to meet the needs of the team, unblocks obstacles and supports the team in delivering its goals).</li>
         <li>Regularly takes on more difficult tasks which require input from various teams or disciplines.</li>
@@ -307,7 +307,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
     <td>
       <ul>
         <li>Identifies opportunities for their team to improve their processes or introduce new technologies, and follows through to ensure the intended benefit is realised.</li>
-        <li>Works with Product and Engineering Managers to ensure the most useful product data is gathered and available for decision making.†</li>
+        <li>Works with one or more of Product Managers / Engineering Managers / Data Analysts to ensure useful data is gathered and available for decision making.†</li>
       </ul>
     </td>
     <td>
@@ -379,7 +379,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
     <td>
       <ul>
         <li>Plays a strategic role in the stream’s technical decision making</li>
-        <li>Enhances the streams strategy through data-informed decision-making†.</li>
+        <li>Enhances the strategy of the stream through data-informed decision-making†.</li>
         <li>Produces high quality code which defines stream standards, and inspires other engineers’ delivery.</li>
         <li>Provides feedback on important PRs and team’s solution design sessions.</li>
         <li>Fosters a culture of continuous improvement and high delivery momentum across the stream.</li>
@@ -389,7 +389,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Committed to meeting their team’s objective and key results.</li>
         <li>Helps to unblock obstacles and supports the team in delivering its goals.  </li>
         <li>Takes responsibility of their code from local testing to supporting it in production.</li>
-        <li>Ensures collection and utilisation of relevant and high-quality data for their products.†</li>
+        <li>Ensures collection and utilisation of relevant and high-quality data for their products and systems.†</li>
       </ul>
     </td>
     <td>
@@ -514,7 +514,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Leads collaborative discussions around evolving best practices, defining our engineering standards.</li>
         <li>Seeks out systemic problems and opportunities, and presents proposals to the Head of Engineering on how to, respectively, remediate them and benefit from them.</li>
         <li>Advises on new technology trials based on your previous experience, and mentor more junior developers in their technical discovery and technology intelligence.</li>
-        <li>Works with Product Managers and others to effectively communicate data-informed insights which inspire action from colleagues and stakeholders.†</li>
+        <li>Works with one or more of Product Managers / Engineering Managers / Data Analysts to effectively communicate data-informed insights which inspire action from colleagues and stakeholders.†</li>
       </ul>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Takes on bigger pieces of work with support.</li>
         <li>Takes on PR feedback and improves their work.</li>
         <li>Seeks advice from more senior engineers when they are blocked.</li>
+        <li>Shows awareness of data privacy or security concerns where relevant.</li>
       </ul>
     </td>
     <td>
@@ -108,6 +109,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Contributes ideas for solutions and process improvements in team discussions, and is able to build on the ideas of others.</li>
         <li>Actively exploring new approaches in their own work.</li>
+        <li>Uses relevant data or metrics as an input to solutions.</li>
       </ul>
     </td>
   </tr>
@@ -184,7 +186,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Identifies problems to solve and engages the team in scoping and prioritising their delivery.</li>
         <li>Demonstrates an understanding of external schedule constraints and calls out potential issues during estimation</li>
-        <li>Evaluates multiple options to solve technical problems and is trusted by the team to implement their recommended solution.</li>
+        <li>Evaluates multiple options to solve technical problems using data where relevant, and is trusted by the team to implement their recommended solution.</li>
         <li>Regularly reviews team PRs providing helpful comments (e.g. constructive criticism / alternative approaches). Occasionally reviews PRs in projects where they have less context (e.g. outside their immediate team or dormant projects) with the same consideration.</li>
         <li>Helps to unblock their peers or shares responsibility for their tasks, in order to meet the team delivery goals.</li>
       </ul>
@@ -207,6 +209,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Regularly introduces new technical approaches when appropriate, which are adopted by the team, and make the team more effective. </li>
         <li>Keeps up to date with evolving best practice in their field.</li>
+        <li>Works with Product and Engineering Managers to ensure most useful product data is gathered and available for decision making.</li>
       </ul>
     </td>
   </tr>
@@ -233,6 +236,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Regularly demos their work to the team, stream or stakeholders, and contextualises the impact of that work. </li>
         <li>Supports the team leads in making architectural design decisions (e.g. by writing options papers or architecture decision records). </li>
         <li>Represents the team in cross-team discussions and involves others when appropriate by sharing challenges and progress.</li>
+        <li>Uses relevant data and metrics to inform new ideas and make persuasive arguments</li>
       </ul>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -515,7 +515,6 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Leads collaborative discussions around evolving best practices, defining our engineering standards.</li>
         <li>Seeks out systemic problems and opportunities, and presents proposals to the Head of Engineering on how to, respectively, remediate them and benefit from them.</li>
         <li>Advises on new technology trials based on your previous experience, and mentor more junior developers in their technical discovery and technology intelligence.</li>
-        <li>Is abile to make sense of data and communicate it as easy-to-understand stories that help inspire insights to become actions.</li>
         <li>Is able to effectively work with Product and other disciplines to communicate data insights using narratives, and where appropriate visualizations, to put data insights into context and inspire action from, and give direction to, colleages and stakeholders across the business.</li>
       </ul>
     </td>

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Provides input into architectural design choices. </li>
         <li>Regularly demos their work to the stream. </li>
         <li>Encourages their colleagues to do their best work.</li>
+        <li>Uses relevant data and metrics to inform new ideas and make persuasive arguments</li>
       </ul>
     </td>
     <td>
@@ -236,7 +237,6 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Regularly demos their work to the team, stream or stakeholders, and contextualises the impact of that work. </li>
         <li>Supports the team leads in making architectural design decisions (e.g. by writing options papers or architecture decision records). </li>
         <li>Represents the team in cross-team discussions and involves others when appropriate by sharing challenges and progress.</li>
-        <li>Uses relevant data and metrics to inform new ideas and make persuasive arguments</li>
       </ul>
     </td>
   </tr>
@@ -279,15 +279,17 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Delivers reliably and with consistently good quality code (e.g. well tested and readable) which defines team standards.</li>
         <li>Takes responsibility of their code from local testing to supporting it in production.</li>
-        <li>Regularly reviews team PRs providing helpful comments, constructive criticism or suggested alternative approaches.</li>
+        <li>Regularly reviews team PRs providing helpful comments, constructive criticism or suggested alternative approaches, using relevant data and metrics where approriate.</li>
         <li>Demonstrates understanding that delivery goes beyond their individual contribution. (E.g. encourages others to improve their own delivery; manages dependencies on other projects and teams; balances short-term delivery with longer term objectives of own and other teams).</li>
         <li>Committed to meeting their team’s objective and key results. (E.g. adapts delivery approach to meet the needs of the team, unblocks obstacles and supports the team in delivering its goals).</li>
         <li>Regularly takes on more difficult tasks which require input from various teams or disciplines.</li>
+        <li>Intelligently uses data and metrics to make informed decisions.</li>
       </ul>
     </td>
     <td>
       <ul>
         <li>Plays a leading role in planning technical strategy for the team, or shaping the team’s delivery plans.</li>
+        <li>Informed by other disciplines, champions collecting the right data and metrics for each product.</li>
         <li>Makes their team successful in meeting their objectives and key results.</li>
         <li>Balances risks to ensure team delivery.</li>
         <li>Monitors system and delivery pipeline health to ensure quality of service and team productivity.</li>
@@ -306,6 +308,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
     <td>
       <ul>
         <li>Identifies opportunities for their team to improve their processes or introduce new technologies, and follows through to ensure the intended benefit is realised.</li>
+        <li>Uses data and metrics to identify and propose improvements and new technologies.</li>
       </ul>
     </td>
     <td>
@@ -313,6 +316,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Leads by example to promote and encourage a culture of continuous improvement within their team.</li>
         <li>Performs detailed R&D on new technologies and architecture patterns, and frames and shares the results accordingly.</li>
         <li>Ensures that all members of the team are brought on board with new solutions, processes and technologies.</li>
+        <li>Works with Product, UX and other relevant disciplines to identify potential new opportunities for the business based on data.</li>
       </ul>
     </td>
   </tr>
@@ -376,7 +380,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
   <tr>
     <td>
       <ul>
-        <li>Plays a strategic role in the stream’s technical decision making.</li>
+        <li>Plays a strategic role in the stream’s technical decision making through data-driven decision-making whenever possible.</li>
         <li>Produces high quality code which defines stream standards, and inspires other engineers’ delivery.</li>
         <li>Provides feedback on important PRs and team’s solution design sessions.</li>
         <li>Fosters a culture of continuous improvement and high delivery momentum across the stream.</li>
@@ -386,6 +390,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Committed to meeting their team’s objective and key results.</li>
         <li>Helps to unblock obstacles and supports the team in delivering its goals.  </li>
         <li>Takes responsibility of their code from local testing to supporting it in production.</li>
+        <li>Takes responsibility for ensuring collection of the best data and metrics for their products.</li>
       </ul>
     </td>
     <td>
@@ -441,6 +446,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Champions Guardian P&E solutions, culture and values externally. For example by hosting external meet-ups, presenting at conferences, or writing blog posts. </li>
         <li>Enables software to be produced that can be used by, or benefits external communities.</li>
         <li>Ensures we don’t encounter unmitigatable or unforeseen technical problems.</li>
+        <li>Is abile to make sense of data and communicate it as easy-to-understand stories that help inspire insights to become actions.</li>
       </ul>
     </td>
   </tr>
@@ -509,6 +515,8 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Leads collaborative discussions around evolving best practices, defining our engineering standards.</li>
         <li>Seeks out systemic problems and opportunities, and presents proposals to the Head of Engineering on how to, respectively, remediate them and benefit from them.</li>
         <li>Advises on new technology trials based on your previous experience, and mentor more junior developers in their technical discovery and technology intelligence.</li>
+        <li>Is abile to make sense of data and communicate it as easy-to-understand stories that help inspire insights to become actions.</li>
+        <li>Is able to effectively work with Product and other disciplines to communicate data insights using narratives, and where appropriate visualizations, to put data insights into context and inspire action from, and give direction to, colleages and stakeholders across the business.</li>
       </ul>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Demonstrates understanding that delivery goes beyond their individual contribution. (E.g. encourages others to improve their own delivery; manages dependencies on other projects and teams; balances short-term delivery with longer term objectives of own and other teams).</li>
         <li>Committed to meeting their team’s objective and key results. (E.g. adapts delivery approach to meet the needs of the team, unblocks obstacles and supports the team in delivering its goals).</li>
         <li>Regularly takes on more difficult tasks which require input from various teams or disciplines.</li>
-        <li>Intelligently uses data and metrics to make informed decisions.</li>
+        <li>Intelligently uses data and metrics to make informed decisions.†</li>
       </ul>
     </td>
     <td>
@@ -390,7 +390,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Committed to meeting their team’s objective and key results.</li>
         <li>Helps to unblock obstacles and supports the team in delivering its goals.  </li>
         <li>Takes responsibility of their code from local testing to supporting it in production.</li>
-        <li>Takes responsibility for ensuring collection of the best data and metrics for their products.</li>
+        <li>Takes responsibility for ensuring collection of the best data and metrics for their products.†</li>
       </ul>
     </td>
     <td>
@@ -446,7 +446,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Champions Guardian P&E solutions, culture and values externally. For example by hosting external meet-ups, presenting at conferences, or writing blog posts. </li>
         <li>Enables software to be produced that can be used by, or benefits external communities.</li>
         <li>Ensures we don’t encounter unmitigatable or unforeseen technical problems.</li>
-        <li>Is able to make sense of data and present it in easy-to-understand and inspiring formats</li>
+        <li>Is able to make sense of data and present it in easy-to-understand and inspiring formats.†</li>
       </ul>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Committed to meeting their team’s objective and key results.</li>
         <li>Helps to unblock obstacles and supports the team in delivering its goals.  </li>
         <li>Takes responsibility of their code from local testing to supporting it in production.</li>
-        <li>Ensures collection of relevant and high-quality data for their products, and that this data is used for impactful metrics or key results.†</li>
+        <li>Ensures collection and utilisation of relevant and high-quality data for their products.†</li>
       </ul>
     </td>
     <td>

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Critically evaluates innovative concepts and ideas presented by others.</li>
         <li>Suggests and helps to implement process improvements and engineering best practice.</li>
-        <li>Works with one or more of Product Managers / Engineering Managers / Data Analysts to ensure the most useful product data is gathered and available for analysis & decision making.†</li>
+        <li>Works with one or more of Product Managers / Engineering Managers / Data Analysts to ensure relevant data is gathered and available for analysis & decision making.†</li>
       </ul>
     </td>
     <td>
@@ -307,7 +307,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
     <td>
       <ul>
         <li>Identifies opportunities for their team to improve their processes or introduce new technologies, and follows through to ensure the intended benefit is realised.</li>
-        <li>Works with one or more of Product Managers / Engineering Managers / Data Analysts to ensure useful data is gathered and available for decision making.†</li>
+        <li>Works with one or more of Product Managers / Engineering Managers / Data Analysts to ensure relevant data is gathered and available for analysis & decision making.†</li>
       </ul>
     </td>
     <td>

--- a/README.md
+++ b/README.md
@@ -203,13 +203,13 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
       <ul>
         <li>Critically evaluates innovative concepts and ideas presented by others.</li>
         <li>Suggests and helps to implement process improvements and engineering best practice.</li>
+        <li>Works with Product and others to ensure the most useful product data is gathered and available for decision making.†</li>
       </ul>
     </td>
     <td>
       <ul>
         <li>Regularly introduces new technical approaches when appropriate, which are adopted by the team, and make the team more effective. </li>
         <li>Keeps up to date with evolving best practice in their field.</li>
-        <li>Works with Product and Engineering Managers to ensure most useful product data is gathered and available for decision making.†</li>
       </ul>
     </td>
   </tr>
@@ -283,7 +283,6 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Demonstrates understanding that delivery goes beyond their individual contribution. (E.g. encourages others to improve their own delivery; manages dependencies on other projects and teams; balances short-term delivery with longer term objectives of own and other teams).</li>
         <li>Committed to meeting their team’s objective and key results. (E.g. adapts delivery approach to meet the needs of the team, unblocks obstacles and supports the team in delivering its goals).</li>
         <li>Regularly takes on more difficult tasks which require input from various teams or disciplines.</li>
-        <li>Intelligently uses data and metrics to make informed decisions.†</li>
       </ul>
     </td>
     <td>
@@ -308,7 +307,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
     <td>
       <ul>
         <li>Identifies opportunities for their team to improve their processes or introduce new technologies, and follows through to ensure the intended benefit is realised.</li>
-        <li>Uses data and metrics to identify and propose improvements and new technologies.</li>
+        <li>Works with Product and Engineering Managers to ensure the most useful product data is gathered and available for decision making.†</li>
       </ul>
     </td>
     <td>
@@ -316,7 +315,6 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Leads by example to promote and encourage a culture of continuous improvement within their team.</li>
         <li>Performs detailed R&D on new technologies and architecture patterns, and frames and shares the results accordingly.</li>
         <li>Ensures that all members of the team are brought on board with new solutions, processes and technologies.</li>
-        <li>Works with Product, UX and other relevant disciplines to identify potential new opportunities for the business based on data.†</li>
       </ul>
     </td>
   </tr>
@@ -380,7 +378,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
   <tr>
     <td>
       <ul>
-        <li>Plays a strategic role in the stream’s technical decision making through data-driven decision-making whenever possible†.</li>
+        <li>Plays a strategic role in the stream’s technical decision making through data-informed decision-making whenever possible†.</li>
         <li>Produces high quality code which defines stream standards, and inspires other engineers’ delivery.</li>
         <li>Provides feedback on important PRs and team’s solution design sessions.</li>
         <li>Fosters a culture of continuous improvement and high delivery momentum across the stream.</li>
@@ -390,7 +388,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Committed to meeting their team’s objective and key results.</li>
         <li>Helps to unblock obstacles and supports the team in delivering its goals.  </li>
         <li>Takes responsibility of their code from local testing to supporting it in production.</li>
-        <li>Takes responsibility for ensuring collection of the best data and metrics for their products.†</li>
+        <li>Ensures collection of relevant and high-quality data for their products, and that this data is used for impactful metrics or key results.†</li>
       </ul>
     </td>
     <td>
@@ -446,7 +444,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Champions Guardian P&E solutions, culture and values externally. For example by hosting external meet-ups, presenting at conferences, or writing blog posts. </li>
         <li>Enables software to be produced that can be used by, or benefits external communities.</li>
         <li>Ensures we don’t encounter unmitigatable or unforeseen technical problems.</li>
-        <li>Is able to make sense of data and present it in easy-to-understand and inspiring formats.†</li>
+        <li>Demonstrates deep understanding and engagement with engineering or product data.†</li>
       </ul>
     </td>
   </tr>
@@ -515,7 +513,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Leads collaborative discussions around evolving best practices, defining our engineering standards.</li>
         <li>Seeks out systemic problems and opportunities, and presents proposals to the Head of Engineering on how to, respectively, remediate them and benefit from them.</li>
         <li>Advises on new technology trials based on your previous experience, and mentor more junior developers in their technical discovery and technology intelligence.</li>
-        <li>Is able to effectively work with Product and other disciplines to communicate data insights using narratives, and where appropriate visualizations, to put data insights into context and inspire action from, and give direction to, colleages and stakeholders across the business.†</li>
+        <li>Works with Product Managers and others to effectively communicate data-informed insights which inspire action from colleagues and stakeholders.†</li>
       </ul>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -378,7 +378,8 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
   <tr>
     <td>
       <ul>
-        <li>Plays a strategic role in the stream’s technical decision making through data-informed decision-making whenever possible†.</li>
+        <li>Plays a strategic role in the stream’s technical decision making</li>
+        <li>Enhances the streams strategy through data-informed decision-making†.</li>
         <li>Produces high quality code which defines stream standards, and inspires other engineers’ delivery.</li>
         <li>Provides feedback on important PRs and team’s solution design sessions.</li>
         <li>Fosters a culture of continuous improvement and high delivery momentum across the stream.</li>

--- a/README.md
+++ b/README.md
@@ -521,5 +521,5 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
 </table>
 
 † - Criteria marked with the 'obelisk' icon are new changes (2023-June) that are optional until after the current review round.
-The Engineering Management team are reviewing the progression and promotion frameworks generally, including adding data-related responsibilities. However we believe it's unfair to make changes to the criteria shortly before a review round.
+The Engineering Management team are reviewing the progression and promotion frameworks generally, including adding data-related responsibilities. However we believe it's fair that changes to criteria are made and established well before a review round.
 For now - feel free to provide evidence towards them, or delete them.


### PR DESCRIPTION
Details in this doc: https://docs.google.com/document/d/1VxjbfkguXS9Xa6PxSZIPCcF2dV8ef8wUKQNSugJYdrA/edit#
Discussed in EM meetings mid-2023. Now also upcoming again mid-2024 as the data department no longer exists, so this topic is more pressing again.
Sibling PR for EM framework: https://github.com/guardian/engineering-performance-framework/pull/30
