### PR TITLE
Updating framework for H2 of FY25/26

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,18 +53,19 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
 #### 👩‍👨 People
 
 <table>
-  <tr> <th width="50%">Core Criteria</th><th with="50%">Growth Criteria</th></tr>
+  <tr> <th style="width:50%;">Mets Criteria</th><th style="width:50%;">Exceeds Criteria</th></tr>
   <tr>
     <td>
       <ul>
         <li>Proactively identifies opportunities to work with others.</li>
         <li>Shows curiosity in others and their work.</li>
+        <li>Regularly collaborates with their team on their work.</li>
       </ul>
     </td>
     <td>
       <ul>
-        <li>Regularly collaborates with their team on their work.</li>
         <li>Engages with departmental activities which uphold our departmental or engineering culture.</li>
+        <li>Gives useful feedback to their colleagues.</li>
       </ul>
     </td>
   </tr>
@@ -73,7 +74,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
 #### 🚚 Delivery
 
 <table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
+  <tr> <th style="width:50%;">Meets Criteria</th><th style="width:50%;">Exceeds Criteria</th></tr>
   <tr>
     <td>
       <ul>
@@ -81,35 +82,16 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <li>Takes on bigger pieces of work with support.</li>
         <li>Takes on PR feedback and improves their work.</li>
         <li>Seeks advice from more senior engineers when they are blocked.</li>
-        <li>Shows awareness of data privacy or security concerns where relevant.†</li>
+        <li>Shows awareness of data privacy or security concerns where relevant.</li>
+        <li>Reviews PRs with helpful comments.</li>
       </ul>
     </td>
     <td>
       <ul>
         <li>Breaks down large problems into deliverable tasks.</li>
-        <li>Reliably delivers incremental changes with frequency.  Can work mostly independently and unblocks their work when necessary by proactively reaching out to stakeholders, gathering data or provoking decisions/discussions.</li>
-        <li>Provides support to other engineers.</li>
-        <li>Reviews PRs with helpful comments.</li>
-      </ul>
-    </td>
-  </tr>
-</table>
-
-#### 💡 Innovation
-
-<table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
-  <tr>
-    <td>
-      <ul>
-        <li>Finds creative and effective solutions in their own work.</li>
-      </ul>
-    </td>
-    <td>
-      <ul>
-        <li>Contributes ideas for solutions and process improvements in team discussions, and is able to build on the ideas of others.</li>
-        <li>Actively exploring new approaches in their own work.</li>
-        <li>Uses relevant data or metrics as an input to solutions when relevant.†</li>
+        <li>Reliably delivers incremental changes with frequency.</li>
+        <li>Can work mostly independently and unblocks their work when necessary by proactively reaching out to stakeholders, gathering data or provoking decisions/discussions.</li>
+        <li>Provides delivery support to other engineers.</li>
       </ul>
     </td>
   </tr>
@@ -118,22 +100,21 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
 #### ✨ Initiative and Influence
 
 <table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
+  <tr> <th style="width:50%;">Meets Criteria</th><th style="width:50%;">Exceeds Criteria</th></tr>
   <tr>
     <td>
       <ul>
-        <li>Contributes ideas in team discussions.</li>
-        <li>Occasionally demos their work to the team or stream.</li>
-        <li>Seeks to actively understand what they are being asked to do, and why.</li>
+        <li>Shares their work to the team or stream.</li>
+        <li>Seeks to actively understand what they are being asked to do.</li>
       </ul>
     </td>
     <td>
       <ul>
+        <li>Seeks to understand the why behind what they are being asked to do.</li>
+        <li>Actively explores new approaches in their own work.</li>
         <li>Focuses their learning and development plans to align with team goals.</li>
-        <li>Gives useful feedback to their colleagues.</li>
-        <li>Regularly seizes opportunities such as demos or sponsor meetings, to communicate what they have been working on.</li>
-        <li>Makes data-backed suggestions on what the team should be doing next.</li>
-        <li>Takes opportunities to learn about wider department work through involvement in cross-team discussions or groups such as Accessibility Champions. Represents the team occasionally but is likely to refer more complex issues to others.</li>
+        <li>Uses data to help with their or their team’s decision-making</li>
+        <li>Takes opportunities to learn about wider department work through involvement in cross-team discussions or groups such as Accessibility Champions.</li>
       </ul>
     </td>
   </tr>
@@ -147,21 +128,19 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
 #### 👩‍👨 People
 
 <table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
+  <tr> <th style="width:50%;">Meets Criteria</th><th style="width:50%;">Exceeds Criteria</th></tr>
   <tr>
     <td>
       <ul>
-        <li>Each quarter provides some mentoring or guidance to colleagues (e.g. mentoring, onboarding, constructive PR reviews or discussing approaches online or offline).  This should not simply be contributing an opinion on a technical approach, but taking the time to introduce or improve someone’s understanding of a topic in a supportive and encouraging way. </li>
-        <li>Always willing to help others.</li>
+        <li>Engages with departmental activities which uphold our departmental or engineering culture.</li>
+        <li>Provides some mentoring or guidance to colleagues. This should not simply be contributing an opinion on a technical approach, but taking the time to introduce or improve someone’s working awareness of a topic in a supportive and encouraging way.</li>
         <li>Demonstrates inclusive behaviours as part of their everyday work.</li>
       </ul>
     </td>
     <td>
       <ul>
-        <li>Regularly provides mentoring and guidance to colleagues and has become known for this. </li>
-        <li>Undertakes departmental activities which uphold our departmental or engineering culture.</li>
-        <li>Ensures the opinions of others in their team are heard and that decisions are made by consensus.</li>
-        <li>Participates in some activity which aims to improve the inclusivity of our department.</li>
+        <li>Regularly provides mentoring and guidance to colleagues.</li>
+        <li>Undertakes departmental activities which uphold or improve our engineering culture or inclusivity.</li>
       </ul>
     </td>
   </tr>
@@ -170,46 +149,26 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
 #### 🚚 Delivery
 
 <table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
+  <tr> <th style="width:50%;">Meets Criteria</th><th style="width:50%;">Exceeds Criteria</th></tr>
   <tr>
     <td>
       <ul>
+        <li>Provides delivery support to colleagues.</li>
         <li>Breaks down large problems into deliverable tasks.</li>
-        <li>Delivers incremental changes frequently, reliably and with consistently good quality (e.g readable code which adheres to team standards).</li>
-        <li>Takes responsibility of their code from local testing to supporting it in production.</li>
-        <li>Only occasionally requires support from peers depending on the task, technology and prior experience.</li>
-        <li>Regularly reviews team PRs.</li>
+        <li>Delivers incremental changes frequently, reliably and with consistently good quality (e.g. readable code which adheres to team standards).</li>
+        <li>Takes responsibility for their code from local testing to supporting it in production.</li>
+        <li>Capable of independent delivery of most tasks.</li>
+        <li>Regularly reviews team PRs providing helpful comments (e.g. constructive criticism / alternative approaches).</li>
         <li>Recognises when they’re near their limit and reaches out for help from others.</li>
       </ul>
     </td>
     <td>
       <ul>
         <li>Identifies problems to solve and engages the team in scoping and prioritising their delivery.</li>
-        <li>Demonstrates an understanding of external schedule constraints and calls out potential issues during estimation</li>
-        <li>Evaluates multiple options to solve technical problems (using data where relevant†), and is trusted by the team to implement their recommended solution.</li>
-        <li>Regularly reviews team PRs providing helpful comments (e.g. constructive criticism / alternative approaches). Occasionally reviews PRs in projects where they have less context (e.g. outside their immediate team or dormant projects) with the same consideration.</li>
+        <li>Demonstrates they can work to external schedule constraints and call out potential issues during estimation.</li>
+        <li>Evaluates multiple options to solve technical problems (using data where relevant), and is trusted by the team to implement their recommended solution.</li>
+        <li>Occasionally reviews PRs in projects where they have less context (e.g. outside their immediate team or dormant projects) with the same consideration.</li>
         <li>Helps to unblock their peers or shares responsibility for their tasks, in order to meet the team delivery goals.</li>
-      </ul>
-    </td>
-  </tr>
-</table>
-
-#### 💡 Innovation
-
-<table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
-  <tr>
-    <td>
-      <ul>
-        <li>Critically evaluates innovative concepts and ideas presented by others.</li>
-        <li>Suggests and helps to implement process improvements and engineering best practice.</li>
-        <li>Works with one or more of Product Managers / Engineering Managers / Data Analysts to ensure relevant data is gathered and available for analysis & decision making.†</li>
-      </ul>
-    </td>
-    <td>
-      <ul>
-        <li>Regularly introduces new technical approaches when appropriate, which are adopted by the team, and make the team more effective. </li>
-        <li>Keeps up to date with evolving best practice in their field.</li>
       </ul>
     </td>
   </tr>
@@ -218,25 +177,25 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
 #### ✨ Initiative and Influence
 
 <table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
+  <tr> <th style="width:50%;">Meets Criteria</th><th style="width:50%;">Exceeds Criteria</th></tr>
   <tr>
     <td>
       <ul>
-        <li>Aligns what they are working on to their team’s goals. </li>
-        <li>Regularly gives useful feedback to more senior colleagues. </li>
+        <li>Aligns what they are working on to their team’s goals.</li>
+        <li>Regularly gives useful feedback to more senior colleagues.</li>
         <li>Seeks to fully understand the end goal of the tasks they pick up, and is mindful of this throughout the delivery lifecycle.</li>
-        <li>Provides input into architectural design choices. </li>
-        <li>Regularly demos their work to the stream. </li>
-        <li>Encourages their colleagues to do their best work.</li>
-        <li>Uses relevant data and metrics to inform new ideas and make persuasive arguments.†</li>
+        <li>Provides input into architectural design choices.</li>
+        <li>Regularly demos their work to the stream.</li>
+        <li>Uses relevant data and metrics to inform new ideas and make persuasive arguments.</li>
       </ul>
     </td>
     <td>
       <ul>
-        <li>Regularly gives feedback to the team on improving their ways of working, and to team leads each quarter. Helps to implement some of  these improvements by being an advocate for them.</li>
-        <li>Regularly demos their work to the team, stream or stakeholders, and contextualises the impact of that work. </li>
-        <li>Supports the team leads in making architectural design decisions (e.g. by writing options papers or architecture decision records). </li>
-        <li>Contributes towards maintaining code and product accessibility standards</li>
+        <li>Occasionally introduces new technical approaches, which are adopted by the team, and make the team more effective.</li>
+        <li>Regularly gives feedback to the team on improving their ways of working, and to team leads each quarter. Helps to implement some of these improvements by being an advocate for them.</li>
+        <li>Regularly demos their work to the team, stream or stakeholders, and contextualises the impact of that work.</li>
+        <li>Supports the team leads in making architectural design decisions (e.g. by writing options papers or architecture decision records).</li>
+        <li>Contributes towards maintaining code and product accessibility standards.</li>
         <li>Represents the team in cross-team discussions and involves others when appropriate by sharing challenges and progress.</li>
       </ul>
     </td>
@@ -250,22 +209,21 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
 #### 👩‍👨 People
 
 <table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
+  <tr> <th style="width:50%;">Meets Criteria</th><th style="width:50%;">Exceeds Criteria</th></tr>
   <tr>
     <td>
       <ul>
         <li>Actively seeks to share knowledge with their colleagues, choosing communication method/styles that are appropriate to them and the situation.</li>
-        <li>Makes a positive contribution to the inclusivity, atmosphere and culture of the department.</li>
+        <li>Makes a positive contribution to the inclusivity, atmosphere or culture of the department.</li>
         <li>Regularly advises or mentors others in a way that accelerates their personal development.</li>
       </ul>
     </td>
     <td>
       <ul>
-        <li>Seeks to share knowledge beyond their team where useful/relevant (e.g delegates learning opportunities).</li>
-        <li>Consistently communicates the intention and outcomes from their work, leaving their work in a state where others can easily pick it up (e.g produces well worded requirements, PRs, documentation, etc). Encourages this behaviour in others.</li>
+        <li>Seeks to share knowledge beyond their team where useful/relevant (e.g. delegates learning opportunities).</li>
+        <li>Consistently communicates the intention and outcomes from their work, leaving their work in a state where others can easily pick it up (e.g. produces well worded requirements, PRs, documentation, etc). Encourages this behaviour in others.</li>
         <li>Engages with departmental activities which improve our company or engineering culture and inclusivity.</li>
-        <li>Proactively encourages others to share their opinions and insight. Manages their own input to discussions to ensure they do not overly influence decisions.</li>
-        <li>Coaches and mentors their colleagues to perform better, be happy, motivated and fulfilled in the work they undertake.</li>
+        <li>Coaches, mentors and supports their colleagues to perform better, share their opinions and insight, and be motivated by the work they undertake.</li>
       </ul>
     </td>
   </tr>
@@ -274,48 +232,26 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
 #### 🚚 Delivery
 
 <table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
+  <tr> <th style="width:50%;">Meets Criteria</th><th style="width:50%;">Exceeds Criteria</th></tr>
   <tr>
     <td>
       <ul>
+        <li>Regularly takes on more difficult tasks which require input from other teams or disciplines.</li>
         <li>Delivers reliably and with consistently good quality code (e.g. well tested and readable) which defines team standards.</li>
-        <li>Takes responsibility of their code from local testing to supporting it in production.</li>
-        <li>Regularly reviews team PRs providing helpful comments, constructive criticism or suggested alternative approaches (using relevant data and metrics where relevant†).</li>
-        <li>Demonstrates understanding that delivery goes beyond their individual contribution. (E.g. encourages others to improve their own delivery; manages dependencies on other projects and teams; balances short-term delivery with longer term objectives of own and other teams).</li>
+        <li>Regularly reviews team PRs providing constructive comments, or suggested alternative approaches.</li>
+        <li>Uses relevant data and metrics to support team delivery.</li>
+        <li>Demonstrates working awareness that delivery goes beyond their individual contribution. (E.g. encourages others to improve their own delivery; manages dependencies on other projects and teams; balances short-term delivery with longer term objectives of own and other teams).</li>
         <li>Committed to meeting their team’s objective and key results. (E.g. adapts delivery approach to meet the needs of the team, unblocks obstacles and supports the team in delivering its goals).</li>
-        <li>Regularly takes on more difficult tasks which require input from various teams or disciplines.</li>
+        <li>Communicates and documents their work thoroughly.</li>
       </ul>
     </td>
     <td>
       <ul>
         <li>Plays a leading role in planning technical strategy for the team, or shaping the team’s delivery plans.</li>
-        <li>Informed by other disciplines, champions collecting the right data and metrics for each product.</li>
         <li>Makes their team successful in meeting their objectives and key results.</li>
         <li>Balances risks to ensure team delivery.</li>
         <li>Monitors system and delivery pipeline health to ensure quality of service and team productivity.</li>
         <li>Brings the team or multiple teams together to maintain delivery pace and quality during periods of change and uncertainty.</li>
-        <li>Communicates and documents their work thoroughly.</li>
-      </ul>
-    </td>
-  </tr>
-</table>
-
-#### 💡 Innovation
-
-<table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
-  <tr>
-    <td>
-      <ul>
-        <li>Identifies opportunities for their team to improve their processes or introduce new technologies, and follows through to ensure the intended benefit is realised.</li>
-        <li>Works with one or more of Product Managers / Engineering Managers / Data Analysts to ensure relevant data is gathered and available for analysis & decision making.†</li>
-      </ul>
-    </td>
-    <td>
-      <ul>
-        <li>Leads by example to promote and encourage a culture of continuous improvement within their team.</li>
-        <li>Performs detailed R&D on new technologies and architecture patterns, and frames and shares the results accordingly.</li>
-        <li>Ensures that all members of the team are brought on board with new solutions, processes and technologies.</li>
       </ul>
     </td>
   </tr>
@@ -324,25 +260,26 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
 #### ✨ Initiative and Influence
 
 <table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
+  <tr> <th style="width:50%;">Meets Criteria</th><th style="width:50%;">Exceeds Criteria</th></tr>
   <tr>
     <td>
       <ul>
-        <li>Drives work activities to meet team goals, helping to define tasks, business outcomes, technical quality & OKRs. </li>
-        <li>Helps keep the team focused on their long-term goals and values. </li>
-        <li>Gives regular feedback to the team and engineering manager and actively seeks to make improvements based on team and personal feedback. </li>
-        <li>Works with other engineers to determine the technical architecture within the stream. </li>
-        <li>Shares what they have learnt by tackling difficult technical and people problems.</li>
+        <li>Drives work activities to meet team goals, helping to define tasks, business outcomes, technical quality & OKRs.</li>
+        <li>Helps keep the team focused on their long-term goals and values.</li>
+        <li>Gives regular feedback to the team and engineering manager and actively seeks to make improvements based on team and personal feedback.</li>
+        <li>Works with other engineers to determine the technical architecture within the stream.</li>
         <li>Regularly involved in cross-team discussions and uses their experience to influence outcomes (e.g. communicates own team’s context to improve shared understanding.)</li>
       </ul>
     </td>
     <td>
       <ul>
-        <li>Demonstrably moves the team’s key result scores as a result of the work they undertake. </li>
+        <li>Introduces new technical approaches when appropriate, which are adopted by the team, and make the team more effective.</li>
+        <li>Demonstrably moves the team’s key result scores as a result of the work they undertake.</li>
         <li>Demonstrates how the team can learn and improve from failures.</li>
         <li>Always ensures plans and outcomes are well communicated to stakeholders and the wider business as appropriate.</li>
         <li>Leads work with other teams to solve cross-team challenges. Understands concerns of other teams and works to balance delivery across boundaries in order to deliver the best outcome overall.</li>
-        <li>Is responsible for maintaining code and product accessibility standards</li>
+        <li>Is responsible for maintaining code and product accessibility standards.</li>
+        <li>Shares what they have learnt by tackling difficult technical and people problems.</li>
       </ul>
     </td>
   </tr>
@@ -355,19 +292,19 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
 #### 👩‍👨 People
 
 <table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
+  <tr> <th style="width:50%;">Meets Criteria</th><th style="width:50%;">Exceeds Criteria</th></tr>
   <tr>
     <td>
       <ul>
         <li>Constantly uses their knowledge and experience to raise the capabilities of their colleagues.</li>
-        <li>Leads by example with the quality of their communication through appropriate means (e.g. exemplary requirements, PRs, documentation and presentations that could be understood with little context in the future.)</li>
-        <li>Promotes a culture of respect that influences team processes - leading to effective decision-making and empowerment of others.</li>
+        <li>Leads by example with the quality of their communication through appropriate means (e.g. exemplary requirements, PRs, documentation and presentations that could be understood with little context in the future).</li>
+        <li>Embodies a culture of respect that influences team processes and promotes empowerment of others - leading to more effective decision-making.</li>
       </ul>
     </td>
     <td>
       <ul>
         <li>Identifies potential structural improvements to knowledge sharing, communication or culture of the department and acts on this to deliver improvements across the department.</li>
-        <li>Encourages all staff to perform better, be happy, motivated and fulfilled in the work they undertake.</li>
+        <li>Coaches, mentors and supports all staff to perform better, share their opinions and insight, and be motivated by the work they undertake.</li>
       </ul>
     </td>
   </tr>
@@ -376,22 +313,18 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
 #### 🚚 Delivery
 
 <table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
+  <tr> <th style="width:50%;">Meets Criteria</th><th style="width:50%;">Exceeds Criteria</th></tr>
   <tr>
     <td>
       <ul>
-        <li>Plays a strategic role in the stream’s technical decision making</li>
-        <li>Enhances the strategy of the stream through data-informed decision-making†.</li>
+        <li>Plays a strategic role in the stream’s technical decision-making.</li>
         <li>Produces high quality code which defines stream standards, and inspires other engineers’ delivery.</li>
         <li>Provides feedback on important PRs and team’s solution design sessions.</li>
-        <li>Fosters a culture of continuous improvement and high delivery momentum across the stream.</li>
         <li>Balances short term goals and long term needs.</li>
         <li>Focuses on high impact and high value work.</li>
-        <li>Demonstrates understanding that delivery is more than just their individual contribution. (E.g. Delegates learning opportunities; encourages others to improve their own delivery; manages dependencies on other projects and teams).</li>
+        <li>Demonstrates working awareness that delivery is more than just their individual contribution. (E.g. Promotes continuous improvement, delegates learning opportunities; encourages others to improve their own delivery; manages dependencies on other projects and teams).</li>
         <li>Committed to meeting their team’s objective and key results.</li>
-        <li>Helps to unblock obstacles and supports the team in delivering its goals.  </li>
-        <li>Takes responsibility of their code from local testing to supporting it in production.</li>
-        <li>Ensures collection and utilisation of relevant and high-quality data for their products and systems.†</li>
+        <li>Helps to unblock obstacles and supports the team in delivering its goals.</li>
       </ul>
     </td>
     <td>
@@ -400,7 +333,7 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
         <ul>
         <li>Tech leading a significant engineering project which requires coordination with many other teams and disciplines within GNM.</li>
         <li>Turning around the delivery trajectory of a struggling team.</li>
-        <li>Strategically contributing to the department’s technical and organisational decision making.</li>
+        <li>Contributing to the department’s technical and organisational decision-making and strategy.</li>
         </ul>
         </li>
       </ul>
@@ -408,46 +341,26 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
   </tr>
 </table>
 
-#### 💡 Innovation
-
-<table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
-  <tr>
-    <td>
-      <ul>
-        <li>Identifies systemic problems and opportunities beyond the scope of one team, promotes and considers them with others and evaluates potential solutions. Seeks to find the 80/20 solution that delivers the greatest portion of value for the least effort/cost.</li>
-      </ul>
-    </td>
-    <td>
-      <ul>
-        <li>Introduces new approaches that have an impact on most teams within the department.</li>
-      </ul>
-    </td>
-  </tr>
-</table>
-
-
 #### ✨ Initiative and Influence
 
 <table>
-  <tr> <th width="50%">Core Criteria</th><th width="50%">Growth Criteria</th></tr>
+  <tr> <th style="width:50%;">Meets Criteria</th><th style="width:50%;">Exceeds Criteria</th></tr>
   <tr>
     <td>
       <ul>
-        <li>Hosts department-wide forums where knowledge and experiences are shared. </li>
-        <li>Provides a solid voice of technical authority when there is uncertainty that’s stalling engineering progress. </li>
-        <li>Helps teams determine the right objectives and goals, and find an appropriate balance of health and maintenance alongside their delivery. </li>
-        <li>Helps teams find technical solutions that are cohesive and fit within the department’s vision and culture. </li>
-        <li>Actively works to help engineering teams be set up to succeed.</li>
+        <li>Hosts department-wide forums where knowledge and experiences are shared.</li>
+        <li>Provides a solid voice of technical authority when there is uncertainty that’s stalling engineering progress.</li>
+        <li>Helps teams determine the right objectives and goals, and find an appropriate balance of health and maintenance alongside their delivery.</li>
+        <li>Helps teams find technical solutions that fit within the department’s vision and culture.</li>
       </ul>
     </td>
     <td>
       <ul>
-        <li>Demonstrates how the department can manage failure, fail fast, and learn and improve from such failures. </li>
-        <li>Champions Guardian P&E solutions, culture and values externally. For example by hosting external meet-ups, presenting at conferences, or writing blog posts. </li>
+        <li>Demonstrates how the department can manage failure, fail fast, and learn and improve from such failures.</li>
+        <li>Champions Guardian P&E solutions, culture and values externally. For example by hosting external meet-ups, presenting at conferences, or writing blog posts.</li>
         <li>Enables software to be produced that can be used by, or benefits external communities and is widely accessible.</li>
-        <li>Ensures we don’t encounter unmitigatable or unforeseen technical problems.</li>
-        <li>Demonstrates deep understanding and engagement with engineering or product data.†</li>
+        <li>Works to reduce the likelihood that we will encounter high risk technical problems.</li>
+        <li>Demonstrates deep engagement with and application of engineering or product data.</li>
       </ul>
     </td>
   </tr>
@@ -491,19 +404,6 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
   </tr>
 </table>
 
-#### 💡 Innovation
-
-<table>
-  <tr> <th width="100%">Core Criteria</th></tr>
-  <tr>
-    <td>
-      <ul>
-        <li>Participates actively in the engineering culture of the department through encouraging technical innovation adoption and modelling the behaviours laid out in it.</li>
-        <li>Encourages early adoption of relevant new technologies.</li>
-      </ul>
-  </tr>
-</table>
-
 #### ✨ Initiative and Influence
 
 <table>
@@ -512,16 +412,12 @@ Futher detail [here (staff only)](https://docs.google.com/document/d/1muN4pFqRhL
     <td>
       <ul>
         <li>Attends key meetings with Stakeholders and provide detailed technical views on the subject being discussed.</li>
-        <li>Advises on technical challenges and opportunities in conversations with Product Managers, sponsors and senior stakeholders.</li>
-        <li>Leads collaborative discussions around evolving best practices (such as accessibility standards), defining our engineering standards.</li>
+        <li>Advises, using data where relevant, on technical challenges and opportunities in conversations with Product Managers, sponsors and senior stakeholders.</li>
+        <li>Leads collaborative discussions about evolving best practices (such as accessibility standards), defining our engineering standards.</li>
         <li>Seeks out systemic problems and opportunities, and presents proposals to the Head of Engineering on how to, respectively, remediate them and benefit from them.</li>
         <li>Advises on new technology trials based on your previous experience, and mentor more junior developers in their technical discovery and technology intelligence.</li>
-        <li>Works with one or more of Product Managers / Engineering Managers / Data Analysts to effectively communicate data-informed insights which inspire action from colleagues and stakeholders.†</li>
+        <li>Inspires action from colleagues and stakeholders.</li>
       </ul>
     </td>
   </tr>
 </table>
-
-† - Criteria marked with the 'obelisk' icon are new changes (2024-May) that are optional until after the current review round.
-The Engineering Management team are reviewing the progression and promotion frameworks generally, including adding data-related responsibilities. However we believe it's fair that changes to criteria are made and established well before a review round.
-For now - feel free to provide evidence towards them, or delete them.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Updating framework to remove Innovation category and apply minor edits for clarity.

- Removed Innovation category from all roles
- Removed Fellow as a job title alongside Associate
- Renamed Core and Growth criteria to Meets and Exceeds criteria for all non-Principal roles
- Moved any references to “collaboration” or “gives feedback” to be Meets-level criteria
- Dialled down “data” criteria for Associate and addressed that they are unlikely to attend Sponsor sessions
- Changed the measure of someone “understanding” something to be “working awareness” of that thing
- Slight rewording of a few other bits of criteria for clarity

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
